### PR TITLE
added soft_wrap to prevent newlines in keys

### DIFF
--- a/authum/plugins/aws/__init__.py
+++ b/authum/plugins/aws/__init__.py
@@ -8,7 +8,7 @@ import authum.plugin
 import authum.plugins.aws.lib
 
 
-rich_stdout = rich.console.Console()
+rich_stdout = rich.console.Console(soft_wrap=True)
 rich_stderr = rich.console.Console(stderr=True)
 
 


### PR DESCRIPTION
Context: https://cirrusmd.slack.com/archives/C012H0RUH32/p1656453308284819

To prevent newlines being added to keys exported via `eval "$(athm aws export [url])"`, added `soft_wrap=True`, which prevents `rich.console` from detecting the console width and inserting hard newlines in the text. Tested locally and resolves the issue without introducing any other bugs that I can see.