### PR TITLE
Named AWS sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## Unreleased
 
+## 0.3.0 - 2022-07-20
+
+- [aws] Assume-role sessions now have a many-to-one relationship with apps. The
+  session name defaults to the name of the app, but it can be overridden with
+  the `-n/--session-name` option. Note that the internal representation of
+  sessions has changed, so you should recreate all your sessions to avoid errors
+  (i.e. `athm aws rm -a`, `athm aws add ...`).
+- Miscellaneous bugfixes
+
 ## 0.2.0 - 2022-07-14
 
 - Added graphical MFA prompts

--- a/authum/persistence.py
+++ b/authum/persistence.py
@@ -84,6 +84,7 @@ class KeyringItem(MutableMapping):
         log.debug(f"Deleting keyring item: '{self._service}.{self._name}'")
         try:
             keyring.delete_password(self._service, self._name)
+            self._data = {}
         except keyring.errors.PasswordDeleteError as e:
             if "not found" not in str(e):
                 raise

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "authum"
-version = "0.2.0"
+version = "0.3.0"
 description = "Awesome authentication tool for connecting command line applications to SAML identity and service providers."
 authors = ["CirrusMD <devops@cirrusmd.com>"]
 homepage = "https://github.com/CirrusMD/authum"

--- a/tests/test_aws_lib.py
+++ b/tests/test_aws_lib.py
@@ -57,4 +57,5 @@ def test_aws_data(random_url, session):
     assert ad.session(random_url) == session
 
     ad.rm_session(random_url)
-    assert ad.session(random_url) == authum.plugins.aws.lib.AWSSession()
+    with pytest.raises(authum.plugins.aws.lib.AWSPluginError):
+        ad.session(random_url)

--- a/tests/test_persistence.py
+++ b/tests/test_persistence.py
@@ -48,5 +48,7 @@ def test_keyring_item_save(k):
 
 def test_keyring_item_delete(k):
     k.delete()
+    assert k.asdict() == {}
+
     new_k = authum.persistence.KeyringItem(k.keyring_item_name)
     assert new_k.asdict() == {}


### PR DESCRIPTION
- Assume-role sessions now have a many-to-one relationship with apps. The session name defaults to the name of the app, but it can be overridden with the `-n/--session-name` option. Note that the internal representation of sessions has changed, so you should recreate all your sessions to avoid errors (i.e. `athm aws rm -a`, `athm aws add ...`).
- Miscellaneous bugfixes
- Bumped version to `0.3.0`.